### PR TITLE
Potential fix for code scanning alert no. 9: Reflected cross-site scripting

### DIFF
--- a/internal/logging/request_logger.go
+++ b/internal/logging/request_logger.go
@@ -102,12 +102,13 @@ func logRequestDetails(c *gin.Context, logger *ContextLogger, config RequestResp
 	req := c.Request
 
 	// Build request info
-	requestInfo := fmt.Sprintf("REQUEST %s %s", req.Method, req.URL.Path)
+	escapedPath := html.EscapeString(req.URL.Path)
+	requestInfo := fmt.Sprintf("REQUEST %s %s", req.Method, escapedPath)
 	if req.URL.RawQuery != "" {
 		if config.RedactTokens {
-			requestInfo += "?" + RedactSensitiveInfo(req.URL.RawQuery)
+			requestInfo += "?" + RedactSensitiveInfo(html.EscapeString(req.URL.RawQuery))
 		} else {
-			requestInfo += "?" + req.URL.RawQuery
+			requestInfo += "?" + html.EscapeString(req.URL.RawQuery)
 		}
 	}
 


### PR DESCRIPTION
Potential fix for [https://github.com/ericfitz/tmi/security/code-scanning/9](https://github.com/ericfitz/tmi/security/code-scanning/9)

To remediate this issue, any data written to logs that might have originated from unsanitized user input (especially HTTP request URLs/paths, headers, bodies) should be properly escaped before being logged. The best practice is to apply contextual encoding (such as HTML-escaping) if logs are or could be displayed unescaped in HTML. Given the `logger.Debug("%s", requestInfo)` line is already wrapping some request info, and user input can enter via paths, queries, etc., the safest approach is to escape these strings with `html.EscapeString` or a context-appropriate escapes chain before passing them into loggers. For consistency and to enforce safety, we should also sanitize the data being written from the custom `responseWriter` if relevant, especially if response contents could include user-generated content.

Specifically, in `logRequestDetails`, the construction and logging of `requestInfo` should escape any user-provided components. Additionally, in `responseWriter.Write`, we should sanitize data before writing to the buffer and the underlying writer (if logs are potentially being displayed in a browser).

Required changes:
- Sanitize request path and query when constructing `requestInfo` before logging.
- Optionally, in `responseWriter.Write`, ensure any data logged that may be derived from the request is escaped, particularly if the body can be rendered back to the user (depending on application needs).
- Only import `"html"` (already imported) and use `html.EscapeString` as necessary for escaping string data.
- Do not alter the logging core or log format, only escape user-controlled values as they enter logs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
