### PR TITLE
feat(security): add CodeQL query pack for slogging sanitizer awareness

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -7,6 +7,8 @@ name: "TMI CodeQL Config"
 queries:
   - uses: security-extended
   - uses: security-and-quality
+  # Custom queries that understand TMI's slogging sanitizer
+  - uses: ./.github/codeql/custom-queries
 
 # Path filters - exclude generated code and development-only scripts
 paths-ignore:
@@ -24,28 +26,32 @@ query-filters:
   # These are development-only tools that intentionally log OAuth tokens for debugging
   - exclude:
       id: py/clear-text-logging-sensitive-data
+  # Exclude default go/log-injection query - replaced by our custom query
+  # that understands the slogging package's SanitizeLogMessage() sanitizer
+  - exclude:
+      id: go/log-injection
 
 # =============================================================================
-# RESOLVED - Log Injection (go/log-injection) - FIXED IN CODE
+# RESOLVED - Log Injection (go/log-injection) - CUSTOM QUERY PACK
 # =============================================================================
-# As of this commit, the TMI slogging package now sanitizes all log messages
-# by calling SanitizeLogMessage() which removes newlines, carriage returns,
-# and tabs that could be used for log injection attacks (CWE-117).
+# The TMI slogging package sanitizes all log messages by calling
+# SanitizeLogMessage() which removes newlines, carriage returns, and tabs
+# that could be used for log injection attacks (CWE-117).
 #
-# Files updated:
-#   - internal/slogging/logger.go: Logger.Debug/Info/Warn/Error methods
-#   - internal/slogging/context.go: FallbackLogger and ContextLogger methods
+# CodeQL's default go/log-injection query doesn't understand that slogging
+# methods are safe sinks. We've created a custom CodeQL query pack that:
 #
-# The sanitization happens at the logging layer, so all callers automatically
-# benefit from this protection without needing to modify their code.
+#   1. Models SanitizeLogMessage() as a sanitizer that breaks taint flow
+#   2. Models all slogging methods (Logger, ContextLogger, FallbackLogger)
+#      as safe sinks since they call SanitizeLogMessage() internally
 #
-# After the next CodeQL scan, existing alerts should be resolved because:
-#   1. User input flows into logger.Debug/Info/Warn/Error calls
-#   2. These methods now call SanitizeLogMessage() before logging
-#   3. SanitizeLogMessage() strips control characters, breaking the taint flow
+# Custom query files:
+#   - .github/codeql/custom-queries/go/slogging/SloggingSanitizers.qll
+#   - .github/codeql/custom-queries/go/slogging/LogInjectionWithSlogging.ql
 #
-# If alerts persist after the fix is merged, they can be dismissed as
-# "Fixed in code" with reference to this configuration comment.
+# The default go/log-injection query is excluded above and replaced by our
+# custom query (go/log-injection-slogging-aware) which understands the
+# slogging sanitization.
 # =============================================================================
 
 # =============================================================================

--- a/.github/codeql/custom-queries/go/slogging/LogInjectionWithSlogging.ql
+++ b/.github/codeql/custom-queries/go/slogging/LogInjectionWithSlogging.ql
@@ -1,0 +1,24 @@
+/**
+ * @name Log injection (with slogging sanitizer awareness)
+ * @description Building log entries from user-controlled data may allow
+ *              attackers to forge log entries, obscure security events,
+ *              or corrupt log files. This query is aware of the TMI slogging
+ *              package's built-in sanitization.
+ * @kind path-problem
+ * @problem.severity warning
+ * @security-severity 7.8
+ * @precision high
+ * @id go/log-injection-slogging-aware
+ * @tags security
+ *       external/cwe/cwe-117
+ */
+
+import go
+import semmle.go.security.LogInjection
+import SloggingSanitizers
+import LogInjection::Flow::PathGraph
+
+from LogInjection::Flow::PathNode source, LogInjection::Flow::PathNode sink
+where LogInjection::Flow::flowPath(source, sink)
+select sink.getNode(), source, sink, "Log entry depends on a $@.", source.getNode(),
+  "user-provided value"

--- a/.github/codeql/custom-queries/go/slogging/SloggingSanitizers.qll
+++ b/.github/codeql/custom-queries/go/slogging/SloggingSanitizers.qll
@@ -1,0 +1,152 @@
+/**
+ * Models the TMI slogging package as providing sanitization for log injection attacks.
+ *
+ * The slogging package (github.com/ericfitz/tmi/internal/slogging) provides structured
+ * logging with built-in sanitization via SanitizeLogMessage(). This function removes
+ * newlines, carriage returns, and tabs that could be used for log injection attacks (CWE-117).
+ *
+ * All logging methods in the package call SanitizeLogMessage() before writing to the log:
+ *   - Logger.Debug/Info/Warn/Error
+ *   - Logger.DebugCtx/InfoCtx/WarnCtx/ErrorCtx
+ *   - ContextLogger.Debug/Info/Warn/Error
+ *   - ContextLogger.DebugCtx/InfoCtx/WarnCtx/ErrorCtx
+ *   - FallbackLogger.Debug/Info/Warn/Error
+ *
+ * This library teaches CodeQL that:
+ *   1. SanitizeLogMessage() is a sanitizer that breaks taint flow for log injection
+ *   2. The logging methods in slogging are safe sinks because they sanitize internally
+ */
+
+import go
+import semmle.go.dataflow.DataFlow
+import semmle.go.security.LogInjection
+
+/**
+ * The slogging package path.
+ */
+private string sloggingPackage() { result = "github.com/ericfitz/tmi/internal/slogging" }
+
+/**
+ * A call to SanitizeLogMessage in the slogging package.
+ * This function sanitizes log messages by removing control characters.
+ */
+class SanitizeLogMessageCall extends DataFlow::CallNode {
+  SanitizeLogMessageCall() {
+    this.getTarget().hasQualifiedName(sloggingPackage(), "SanitizeLogMessage")
+  }
+
+  /** Gets the input argument being sanitized. */
+  DataFlow::Node getInput() { result = this.getArgument(0) }
+
+  /** Gets the sanitized output. */
+  DataFlow::Node getOutput() { result = this.getResult() }
+}
+
+/**
+ * Models SanitizeLogMessage as a sanitizer for log injection.
+ * Data flowing through this function is considered sanitized.
+ */
+class SloggingSanitizer extends LogInjection::Sanitizer {
+  SloggingSanitizer() {
+    exists(SanitizeLogMessageCall call | this = call.getOutput())
+  }
+}
+
+/**
+ * Models calls to slogging Logger methods as safe sinks.
+ * These methods internally call SanitizeLogMessage before logging.
+ */
+class SloggingLoggerMethod extends DataFlow::CallNode {
+  string methodName;
+
+  SloggingLoggerMethod() {
+    exists(Method m |
+      m.hasQualifiedName(sloggingPackage(), "Logger", methodName) and
+      methodName in ["Debug", "Info", "Warn", "Error", "DebugCtx", "InfoCtx", "WarnCtx", "ErrorCtx"] and
+      this = m.getACall()
+    )
+  }
+
+  /** Gets the format/message argument. */
+  DataFlow::Node getMessageArg() {
+    // First argument is always the format string or message
+    result = this.getArgument(0)
+    or
+    // For *Ctx methods, first arg is context, second is message
+    methodName.matches("%Ctx") and result = this.getArgument(1)
+  }
+}
+
+/**
+ * Models calls to slogging ContextLogger methods as safe sinks.
+ * These methods internally call SanitizeLogMessage before logging.
+ */
+class SloggingContextLoggerMethod extends DataFlow::CallNode {
+  string methodName;
+
+  SloggingContextLoggerMethod() {
+    exists(Method m |
+      m.hasQualifiedName(sloggingPackage(), "ContextLogger", methodName) and
+      methodName in ["Debug", "Info", "Warn", "Error", "DebugCtx", "InfoCtx", "WarnCtx", "ErrorCtx"] and
+      this = m.getACall()
+    )
+  }
+
+  /** Gets the format/message argument. */
+  DataFlow::Node getMessageArg() {
+    result = this.getArgument(0)
+  }
+}
+
+/**
+ * Models calls to slogging FallbackLogger methods as safe sinks.
+ * These methods internally call SanitizeLogMessage before logging.
+ */
+class SloggingFallbackLoggerMethod extends DataFlow::CallNode {
+  string methodName;
+
+  SloggingFallbackLoggerMethod() {
+    exists(Method m |
+      m.hasQualifiedName(sloggingPackage(), "FallbackLogger", methodName) and
+      methodName in ["Debug", "Info", "Warn", "Error"] and
+      this = m.getACall()
+    )
+  }
+
+  /** Gets the format/message argument. */
+  DataFlow::Node getMessageArg() {
+    result = this.getArgument(0)
+  }
+}
+
+/**
+ * Extends the LogInjection sanitizer to recognize data flowing into slogging methods.
+ * Since all slogging methods call SanitizeLogMessage internally, any data that reaches
+ * a slogging method is effectively sanitized before being logged.
+ */
+class SloggingMethodSanitizer extends LogInjection::Sanitizer {
+  SloggingMethodSanitizer() {
+    this = any(SloggingLoggerMethod m).getMessageArg()
+    or
+    this = any(SloggingContextLoggerMethod m).getMessageArg()
+    or
+    this = any(SloggingFallbackLoggerMethod m).getMessageArg()
+  }
+}
+
+/**
+ * Models the SimpleLogger interface methods as safe sinks.
+ * The SimpleLogger interface is implemented by Logger, ContextLogger, and FallbackLogger,
+ * all of which sanitize log messages.
+ */
+class SloggingSimpleLoggerCall extends DataFlow::CallNode {
+  SloggingSimpleLoggerCall() {
+    exists(Method m |
+      // Match any method call on a type that implements SimpleLogger
+      // where the receiver type is from the slogging package
+      m.getReceiverType().getUnderlyingType().(PointerType).getBaseType().hasQualifiedName(sloggingPackage(), _) and
+      m.getName() in ["Debug", "Info", "Warn", "Error"] and
+      this = m.getACall()
+    )
+  }
+}

--- a/.github/codeql/custom-queries/qlpack.yml
+++ b/.github/codeql/custom-queries/qlpack.yml
@@ -1,0 +1,11 @@
+# TMI Custom CodeQL Query Pack
+# This pack extends the default Go security queries with TMI-specific models
+#
+# The slogging package sanitizes all log messages to prevent log injection (CWE-117).
+# This pack teaches CodeQL that SanitizeLogMessage() is a sanitizer, preventing
+# false positives when user input flows through the slogging logging methods.
+
+name: tmi/custom-queries
+version: 1.0.0
+libraryPathDependencies:
+  - codeql/go-all

--- a/.version
+++ b/.version
@@ -1,5 +1,5 @@
 {
   "major": 0,
-  "minor": 266,
-  "patch": 12
+  "minor": 269,
+  "patch": 0
 }

--- a/api/version.go
+++ b/api/version.go
@@ -27,9 +27,9 @@ var (
 	// Major version number
 	VersionMajor = "0"
 	// Minor version number
-	VersionMinor = "266"
+	VersionMinor = "269"
 	// Patch version number
-	VersionPatch = "12"
+	VersionPatch = "0"
 	// GitCommit is the git commit hash from build
 	GitCommit = "development"
 	// BuildDate is the build timestamp


### PR DESCRIPTION
## Summary
- Add custom CodeQL query pack that teaches CodeQL about the TMI slogging package's built-in log injection sanitization (CWE-117)
- The pack models `SanitizeLogMessage()` as a sanitizer and all slogging logging methods as safe sinks
- Prevents 579+ false positive log injection alerts

## Test plan
- [ ] CodeQL workflow runs successfully with custom query pack
- [ ] No new log injection alerts are raised for code using slogging methods
- [ ] Existing dismissed alerts remain dismissed

🤖 Generated with [Claude Code](https://claude.com/claude-code)