### PR TITLE
fix(api): fix addon invocation completion and rate limit UX

### DIFF
--- a/.version
+++ b/.version
@@ -1,5 +1,5 @@
 {
   "major": 0,
   "minor": 272,
-  "patch": 1
+  "patch": 2
 }

--- a/api/addon_invocation_quota_store.go
+++ b/api/addon_invocation_quota_store.go
@@ -12,7 +12,7 @@ import (
 
 // Default quota values
 const (
-	DefaultMaxActiveInvocations  = 1
+	DefaultMaxActiveInvocations  = 3 // Allow 3 concurrent invocations per user by default
 	DefaultMaxInvocationsPerHour = 10
 )
 

--- a/api/version.go
+++ b/api/version.go
@@ -29,7 +29,7 @@ var (
 	// Minor version number
 	VersionMinor = "272"
 	// Patch version number
-	VersionPatch = "1"
+	VersionPatch = "2"
 	// GitCommit is the git commit hash from build
 	GitCommit = "development"
 	// BuildDate is the build timestamp

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -1306,7 +1306,7 @@ func setupRouter(config *config.Config) (*gin.Engine, *api.Server) {
 }
 
 // startWebhookWorkers initializes and starts all webhook workers
-func startWebhookWorkers(ctx context.Context) (*api.WebhookEventConsumer, *api.WebhookChallengeWorker, *api.WebhookDeliveryWorker, *api.WebhookCleanupWorker) {
+func startWebhookWorkers(ctx context.Context, cfg *config.Config) (*api.WebhookEventConsumer, *api.WebhookChallengeWorker, *api.WebhookDeliveryWorker, *api.WebhookCleanupWorker) {
 	logger := slogging.Get()
 
 	// Start webhook workers if database and Redis are available
@@ -1354,6 +1354,7 @@ func startWebhookWorkers(ctx context.Context) (*api.WebhookEventConsumer, *api.W
 
 		// Start addon invocation worker
 		api.GlobalAddonInvocationWorker = api.NewAddonInvocationWorker()
+		api.GlobalAddonInvocationWorker.SetBaseURL(cfg.GetBaseURL())
 		if err := api.GlobalAddonInvocationWorker.Start(ctx); err != nil {
 			logger.Error("Failed to start addon invocation worker: %v", err)
 		}
@@ -1444,7 +1445,7 @@ func main() {
 	apiServer.StartWebSocketHub(ctx)
 
 	// Initialize and start webhook workers
-	webhookConsumer, challengeWorker, deliveryWorker, cleanupWorker := startWebhookWorkers(ctx)
+	webhookConsumer, challengeWorker, deliveryWorker, cleanupWorker := startWebhookWorkers(ctx, cfg)
 
 	// Prepare address
 	addr := fmt.Sprintf("%s:%s", cfg.Server.Interface, cfg.Server.Port)


### PR DESCRIPTION
## Summary

Fixes addon invocation issues where users get 429 errors because invocations never complete:

- **Auto-complete invocations by default** - Webhooks no longer need to call back unless they opt-in with `X-TMI-Callback: async` header
- **Increase default max active invocations** from 1 to 3 concurrent
- **Enhanced 429 response** with blocking invocation details (IDs, expiry times, retry-after)
- **Auto-infer server base URL** for callback URLs if not explicitly configured

## Changes

| File | Change |
|------|--------|
| `internal/config/config.go` | Add `BaseURL` field with `GetBaseURL()` auto-inference |
| `api/addon_invocation_worker.go` | Use configured base URL, implement X-TMI-Callback auto-complete |
| `api/addon_invocation_quota_store.go` | Change `DefaultMaxActiveInvocations` from 1 to 3 |
| `api/addon_invocation_store.go` | Add `ListActiveForUser` interface and Redis implementation |
| `api/addon_rate_limiter.go` | Enhanced 429 response with `blocking_invocations` array |
| `api/request_utils.go` | Add `Retry-After` header for 429 responses |
| `cmd/server/main.go` | Wire up base URL to addon invocation worker |
| `docs/developer/addons/addon-development-guide.md` | Document callback modes |

## Behavior Changes

1. **Invocations auto-complete by default** - When webhook returns 2xx without `X-TMI-Callback: async`, invocation is marked `completed`
2. **3 concurrent invocations allowed** (was 1)
3. **429 responses include helpful details**:
   - `blocking_invocations[]` with invocation IDs, addon IDs, status, expiry times
   - `retry_after` seconds until oldest invocation times out
   - `Retry-After` HTTP header per RFC 6585
4. **Base URL auto-inferred** from `interface`, `port`, and `tls_enabled` if not set

## Test plan

- [x] `make lint` - 0 issues
- [x] `make build-server` - SUCCESS
- [x] `make test-unit` - All passed
- [ ] Manual test: invoke addon, verify auto-complete
- [ ] Manual test: invoke 3+ addons, verify 429 with details

🤖 Generated with [Claude Code](https://claude.com/claude-code)