### PR TITLE
feat(auth): startup validation + runtime backstop for OAuth providers

### DIFF
--- a/auth/config_adapter.go
+++ b/auth/config_adapter.go
@@ -3,6 +3,7 @@ package auth
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/ericfitz/tmi/api/models"
 	"github.com/ericfitz/tmi/auth/db"
@@ -127,6 +128,11 @@ func InitAuthWithDB(dbManager *db.Manager, unified *config.Config) (*Handlers, e
 	}
 
 	authConfig := ConfigFromUnified(unified)
+
+	if err := validateOAuthProvidersAtStartup(authConfig.OAuth.Providers); err != nil {
+		return nil, fmt.Errorf("oauth provider validation: %w", err)
+	}
+
 	logger := slogging.Get()
 
 	logger.Info("[AUTH_CONFIG_ADAPTER] Initializing auth system with provided database manager")
@@ -158,6 +164,11 @@ func InitAuthWithDB(dbManager *db.Manager, unified *config.Config) (*Handlers, e
 // db.Manager to InitAuthWithDB instead.
 func InitAuthWithConfig(router *gin.Engine, unified *config.Config) (*Handlers, error) {
 	authConfig := ConfigFromUnified(unified)
+
+	if err := validateOAuthProvidersAtStartup(authConfig.OAuth.Providers); err != nil {
+		return nil, fmt.Errorf("oauth provider validation: %w", err)
+	}
+
 	logger := slogging.Get()
 
 	logger.Warn("[AUTH_CONFIG_ADAPTER] Using deprecated InitAuthWithConfig - prefer InitAuthWithDB for explicit dependency injection")
@@ -212,4 +223,37 @@ func InitAuthWithConfig(router *gin.Engine, unified *config.Config) (*Handlers, 
 
 	logger.Info("Authentication system initialized successfully (database type: %s)", gormConfig.Type)
 	return handlers, nil
+}
+
+const (
+	oidcDiscoveryTimeout  = 5 * time.Second
+	oidcDiscoveryCacheTTL = 24 * time.Hour
+	oidcStartupBudget     = 30 * time.Second
+)
+
+// validateOAuthProvidersAtStartup runs the OIDC-discovery-based classifier
+// against every enabled OAuth provider and refuses startup if any provider is
+// not safe to enable. (Issue #288)
+func validateOAuthProvidersAtStartup(providers map[string]OAuthProviderConfig) error {
+	logger := slogging.Get()
+	client := NewDiscoveryClient(oidcDiscoveryTimeout, oidcDiscoveryCacheTTL)
+	ctx, cancel := context.WithTimeout(context.Background(), oidcStartupBudget)
+	defer cancel()
+
+	errs := ValidateAllOAuthProviders(ctx, client, providers)
+	if len(errs) > 0 {
+		for _, e := range errs {
+			logger.Error("[STARTUP] OAuth provider validation failed: %s", e)
+		}
+		return fmt.Errorf("oauth provider validation failed: %d provider(s) misconfigured", len(errs))
+	}
+
+	enabledCount := 0
+	for _, p := range providers {
+		if p.Enabled {
+			enabledCount++
+		}
+	}
+	logger.Info("[STARTUP] OAuth provider validation passed for %d enabled provider(s)", enabledCount)
+	return nil
 }

--- a/auth/config_adapter.go
+++ b/auth/config_adapter.go
@@ -243,7 +243,7 @@ func validateOAuthProvidersAtStartup(providers map[string]OAuthProviderConfig) e
 	errs := ValidateAllOAuthProviders(ctx, client, providers)
 	if len(errs) > 0 {
 		for _, e := range errs {
-			logger.Error("[STARTUP] OAuth provider validation failed: %s", e)
+			logger.Error("[AUTH_CONFIG_ADAPTER] OAuth provider validation failed: %s", e)
 		}
 		return fmt.Errorf("oauth provider validation failed: %d provider(s) misconfigured", len(errs))
 	}
@@ -254,6 +254,6 @@ func validateOAuthProvidersAtStartup(providers map[string]OAuthProviderConfig) e
 			enabledCount++
 		}
 	}
-	logger.Info("[STARTUP] OAuth provider validation passed for %d enabled provider(s)", enabledCount)
+	logger.Info("[AUTH_CONFIG_ADAPTER] OAuth provider validation passed for %d enabled provider(s)", enabledCount)
 	return nil
 }

--- a/auth/handlers_token.go
+++ b/auth/handlers_token.go
@@ -176,6 +176,18 @@ func (h *Handlers) handleAuthorizationCodeGrant(c *gin.Context, code, codeVerifi
 		return
 	}
 
+	// Runtime backstop (#288): if claim extraction completed without a
+	// subject, the provider config is broken — startup validation should
+	// have caught it, but we may be running a hot-deployed config or hit a
+	// transient provider response anomaly. Return 502 with a non-leaky
+	// message; the operator gets full diagnostics in the server log.
+	if userInfo.ID == "" {
+		body, msg := emptySubjectError(providerID, userInfo.Email)
+		slogging.Get().WithContext(c).Error("%s", msg)
+		c.JSON(http.StatusBadGateway, body)
+		return
+	}
+
 	// Extract email from userInfo or claims with fallback
 	email, err := h.extractEmailWithFallback(c, providerID, userInfo, claims)
 	if err != nil {

--- a/auth/handlers_token_helpers.go
+++ b/auth/handlers_token_helpers.go
@@ -1,0 +1,23 @@
+package auth
+
+import (
+	"fmt"
+
+	"github.com/gin-gonic/gin"
+)
+
+// emptySubjectError returns the gin.H body to send when claim extraction
+// yields an empty user_id, and the matching log message for operators.
+// Returned separately from the handler so the diagnostic format can be
+// unit-tested without building a full handler stack.
+func emptySubjectError(providerID, email string) (gin.H, string) {
+	body := gin.H{
+		"error":             "provider_response_invalid",
+		"error_description": "Authentication provider returned incomplete profile data. Please contact the administrator.",
+	}
+	msg := fmt.Sprintf(
+		"Runtime backstop triggered: claim extraction produced empty user_id (provider_id=%s, user_email=%s, subject_claim_path_default=sub). Likely cause: missing OAUTH_PROVIDERS_%s_USERINFO_CLAIMS_SUBJECT_CLAIM mapping. See issue #288.",
+		providerID, email, providerIDToEnvKey(providerID),
+	)
+	return body, msg
+}

--- a/auth/handlers_token_helpers_test.go
+++ b/auth/handlers_token_helpers_test.go
@@ -1,0 +1,36 @@
+package auth
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestEmptySubjectError_BodyShape(t *testing.T) {
+	body, _ := emptySubjectError("github", "alice@example.com")
+
+	errCode, ok := body["error"].(string)
+	if !ok || errCode != "provider_response_invalid" {
+		t.Errorf("error code = %v, want \"provider_response_invalid\"", body["error"])
+	}
+	desc, ok := body["error_description"].(string)
+	if !ok || !strings.Contains(desc, "incomplete profile data") {
+		t.Errorf("error_description = %v, want to mention incomplete profile data", body["error_description"])
+	}
+	// The user-facing body must NOT leak internal terms — operators get the
+	// detail in logs, end users get a generic message via the API.
+	if strings.Contains(desc, "provider_user_id") || strings.Contains(desc, "subject_claim") || strings.Contains(desc, "OAUTH_PROVIDERS") {
+		t.Errorf("error_description leaked internal terms: %s", desc)
+	}
+}
+
+func TestEmptySubjectError_LogMessage(t *testing.T) {
+	_, msg := emptySubjectError("badprovider", "bob@example.com")
+
+	// The log message must include the provider ID, the env var to set, and
+	// the issue reference for operators trying to fix the config.
+	for _, want := range []string{"badprovider", "BADPROVIDER", "subject_claim", "OAUTH_PROVIDERS_BADPROVIDER_USERINFO_CLAIMS_SUBJECT_CLAIM", "#288"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("log message missing %q; got: %s", want, msg)
+		}
+	}
+}

--- a/auth/oidc_discovery.go
+++ b/auth/oidc_discovery.go
@@ -67,6 +67,9 @@ func (c *DiscoveryClient) Discover(ctx context.Context, issuerURL string) (*OIDC
 		return nil, fmt.Errorf("issuerURL is empty")
 	}
 
+	// Cache lookup: intentionally not singleflight-ed. Concurrent first-fetches
+	// for the same issuer may duplicate the upstream request; acceptable for
+	// our use case (handful of providers validated once at startup).
 	c.mu.RLock()
 	if entry, ok := c.cache[issuerURL]; ok && time.Since(entry.fetchedAt) < c.cacheTTL {
 		c.mu.RUnlock()
@@ -80,7 +83,7 @@ func (c *DiscoveryClient) Discover(ctx context.Context, issuerURL string) (*OIDC
 		return nil, err
 	}
 
-	resp, err := c.httpClient.Do(req) //nolint:gosec
+	resp, err := c.httpClient.Do(req) //nolint:gosec // G107: issuerURL is operator-configured by design
 	if err != nil {
 		c.storeCache(issuerURL, nil)
 		return nil, nil // network error -> not OIDC

--- a/auth/oidc_discovery.go
+++ b/auth/oidc_discovery.go
@@ -1,0 +1,26 @@
+package auth
+
+// OIDCDiscoveryDoc represents the subset of an OpenID Connect Discovery 1.0
+// metadata document we need to classify an OAuth provider. Field names match
+// the spec; only the fields we consume are declared.
+type OIDCDiscoveryDoc struct {
+	Issuer                 string   `json:"issuer"`
+	AuthorizationEndpoint  string   `json:"authorization_endpoint"`
+	TokenEndpoint          string   `json:"token_endpoint"`
+	UserinfoEndpoint       string   `json:"userinfo_endpoint"`
+	JWKSURI                string   `json:"jwks_uri"`
+	SubjectTypesSupported  []string `json:"subject_types_supported"`
+	ResponseTypesSupported []string `json:"response_types_supported"`
+}
+
+// IsValid reports whether doc has the minimum fields required by the OIDC
+// Discovery 1.0 spec. userinfo_endpoint is RECOMMENDED rather than REQUIRED;
+// callers that need it should check separately.
+func (d *OIDCDiscoveryDoc) IsValid() bool {
+	return d.Issuer != "" &&
+		d.AuthorizationEndpoint != "" &&
+		d.TokenEndpoint != "" &&
+		d.JWKSURI != "" &&
+		len(d.SubjectTypesSupported) > 0 &&
+		len(d.ResponseTypesSupported) > 0
+}

--- a/auth/oidc_discovery.go
+++ b/auth/oidc_discovery.go
@@ -1,5 +1,15 @@
 package auth
 
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+)
+
 // OIDCDiscoveryDoc represents the subset of an OpenID Connect Discovery 1.0
 // metadata document we need to classify an OAuth provider. Field names match
 // the spec; only the fields we consume are declared.
@@ -23,4 +33,84 @@ func (d *OIDCDiscoveryDoc) IsValid() bool {
 		d.JWKSURI != "" &&
 		len(d.SubjectTypesSupported) > 0 &&
 		len(d.ResponseTypesSupported) > 0
+}
+
+const wellKnownPath = "/.well-known/openid-configuration"
+
+type cachedEntry struct {
+	doc       *OIDCDiscoveryDoc
+	fetchedAt time.Time
+}
+
+type DiscoveryClient struct {
+	httpClient *http.Client
+	cacheTTL   time.Duration
+	mu         sync.RWMutex
+	cache      map[string]cachedEntry
+}
+
+func NewDiscoveryClient(timeout, cacheTTL time.Duration) *DiscoveryClient {
+	return &DiscoveryClient{
+		httpClient: &http.Client{Timeout: timeout},
+		cacheTTL:   cacheTTL,
+		cache:      make(map[string]cachedEntry),
+	}
+}
+
+// Discover fetches and validates the OIDC discovery doc for issuerURL.
+// Returns a valid doc on success. Returns (nil, nil) when the issuer is not
+// OIDC-compliant (404, network error, invalid JSON, or doc fails IsValid) —
+// callers should treat nil-doc as "not OIDC" rather than as an error.
+// Returns (nil, err) only for programmer errors (e.g. invalid issuerURL).
+func (c *DiscoveryClient) Discover(ctx context.Context, issuerURL string) (*OIDCDiscoveryDoc, error) {
+	if issuerURL == "" {
+		return nil, fmt.Errorf("issuerURL is empty")
+	}
+
+	c.mu.RLock()
+	if entry, ok := c.cache[issuerURL]; ok && time.Since(entry.fetchedAt) < c.cacheTTL {
+		c.mu.RUnlock()
+		return entry.doc, nil
+	}
+	c.mu.RUnlock()
+
+	url := strings.TrimSuffix(issuerURL, "/") + wellKnownPath
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := c.httpClient.Do(req) //nolint:gosec
+	if err != nil {
+		c.storeCache(issuerURL, nil)
+		return nil, nil // network error -> not OIDC
+	}
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+
+	if resp.StatusCode != http.StatusOK {
+		c.storeCache(issuerURL, nil)
+		return nil, nil // non-200 -> not OIDC
+	}
+
+	var doc OIDCDiscoveryDoc
+	if err := json.NewDecoder(resp.Body).Decode(&doc); err != nil {
+		c.storeCache(issuerURL, nil)
+		return nil, nil // invalid JSON -> not OIDC
+	}
+
+	if !doc.IsValid() {
+		c.storeCache(issuerURL, nil)
+		return nil, nil // missing required fields -> not OIDC
+	}
+
+	c.storeCache(issuerURL, &doc)
+	return &doc, nil
+}
+
+func (c *DiscoveryClient) storeCache(issuerURL string, doc *OIDCDiscoveryDoc) {
+	c.mu.Lock()
+	c.cache[issuerURL] = cachedEntry{doc: doc, fetchedAt: time.Now()}
+	c.mu.Unlock()
 }

--- a/auth/oidc_discovery_test.go
+++ b/auth/oidc_discovery_test.go
@@ -1,9 +1,114 @@
 package auth
 
 import (
+	"context"
 	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
 	"testing"
+	"time"
 )
+
+func TestDiscoveryClient_Discover_Success(t *testing.T) {
+	body := `{"issuer":"%s","authorization_endpoint":"a","token_endpoint":"t","jwks_uri":"j","userinfo_endpoint":"u","subject_types_supported":["public"],"response_types_supported":["code"]}`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/.well-known/openid-configuration" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprintf(w, body, "https://issuer.example")
+	}))
+	defer srv.Close()
+
+	c := NewDiscoveryClient(2*time.Second, 1*time.Hour)
+	doc, err := c.Discover(context.Background(), srv.URL)
+	if err != nil {
+		t.Fatalf("Discover: %v", err)
+	}
+	if doc == nil {
+		t.Fatal("expected non-nil doc")
+	}
+	if doc.Issuer != "https://issuer.example" {
+		t.Errorf("issuer = %q", doc.Issuer)
+	}
+}
+
+func TestDiscoveryClient_Discover_404(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	c := NewDiscoveryClient(2*time.Second, 1*time.Hour)
+	doc, err := c.Discover(context.Background(), srv.URL)
+	if err != nil {
+		t.Fatalf("expected nil err on 404, got %v", err)
+	}
+	if doc != nil {
+		t.Errorf("expected nil doc on 404, got %+v", doc)
+	}
+}
+
+func TestDiscoveryClient_Discover_InvalidJSON(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = fmt.Fprint(w, "not json")
+	}))
+	defer srv.Close()
+
+	c := NewDiscoveryClient(2*time.Second, 1*time.Hour)
+	doc, err := c.Discover(context.Background(), srv.URL)
+	if err != nil || doc != nil {
+		t.Errorf("invalid JSON: doc=%v err=%v; want both nil", doc, err)
+	}
+}
+
+func TestDiscoveryClient_Discover_MissingRequiredFields(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = fmt.Fprint(w, `{"issuer":"x"}`)
+	}))
+	defer srv.Close()
+
+	c := NewDiscoveryClient(2*time.Second, 1*time.Hour)
+	doc, err := c.Discover(context.Background(), srv.URL)
+	if err != nil || doc != nil {
+		t.Errorf("missing fields: doc=%v err=%v; want both nil", doc, err)
+	}
+}
+
+func TestDiscoveryClient_Discover_CacheHit(t *testing.T) {
+	var hits int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&hits, 1)
+		_, _ = fmt.Fprint(w, `{"issuer":"i","authorization_endpoint":"a","token_endpoint":"t","jwks_uri":"j","subject_types_supported":["public"],"response_types_supported":["code"]}`)
+	}))
+	defer srv.Close()
+
+	c := NewDiscoveryClient(2*time.Second, 1*time.Hour)
+	for i := 0; i < 3; i++ {
+		if _, err := c.Discover(context.Background(), srv.URL); err != nil {
+			t.Fatalf("call %d: %v", i, err)
+		}
+	}
+	if got := atomic.LoadInt32(&hits); got != 1 {
+		t.Errorf("expected 1 upstream call (cached after first), got %d", got)
+	}
+}
+
+func TestDiscoveryClient_Discover_Timeout(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(200 * time.Millisecond)
+	}))
+	defer srv.Close()
+
+	c := NewDiscoveryClient(50*time.Millisecond, 1*time.Hour)
+	doc, err := c.Discover(context.Background(), srv.URL)
+	if err != nil || doc != nil {
+		t.Errorf("timeout: doc=%v err=%v; want both nil", doc, err)
+	}
+}
 
 func TestOIDCDiscoveryDoc_Parse(t *testing.T) {
 	body := []byte(`{
@@ -25,6 +130,9 @@ func TestOIDCDiscoveryDoc_Parse(t *testing.T) {
 	}
 	if doc.UserinfoEndpoint != "https://openidconnect.googleapis.com/v1/userinfo" {
 		t.Errorf("userinfo_endpoint = %q", doc.UserinfoEndpoint)
+	}
+	if !doc.IsValid() {
+		t.Errorf("expected parsed Google doc to be valid")
 	}
 }
 
@@ -53,10 +161,42 @@ func TestOIDCDiscoveryDoc_IsValid(t *testing.T) {
 			want: false,
 		},
 		{
+			name: "missing authorization_endpoint",
+			doc: OIDCDiscoveryDoc{
+				Issuer: "i", TokenEndpoint: "t", JWKSURI: "j",
+				SubjectTypesSupported: []string{"public"}, ResponseTypesSupported: []string{"code"},
+			},
+			want: false,
+		},
+		{
+			name: "missing token_endpoint",
+			doc: OIDCDiscoveryDoc{
+				Issuer: "i", AuthorizationEndpoint: "a", JWKSURI: "j",
+				SubjectTypesSupported: []string{"public"}, ResponseTypesSupported: []string{"code"},
+			},
+			want: false,
+		},
+		{
+			name: "missing jwks_uri",
+			doc: OIDCDiscoveryDoc{
+				Issuer: "i", AuthorizationEndpoint: "a", TokenEndpoint: "t",
+				SubjectTypesSupported: []string{"public"}, ResponseTypesSupported: []string{"code"},
+			},
+			want: false,
+		},
+		{
 			name: "missing subject_types",
 			doc: OIDCDiscoveryDoc{
 				Issuer: "i", AuthorizationEndpoint: "a", TokenEndpoint: "t", JWKSURI: "j",
 				ResponseTypesSupported: []string{"code"},
+			},
+			want: false,
+		},
+		{
+			name: "missing response_types",
+			doc: OIDCDiscoveryDoc{
+				Issuer: "i", AuthorizationEndpoint: "a", TokenEndpoint: "t", JWKSURI: "j",
+				SubjectTypesSupported: []string{"public"},
 			},
 			want: false,
 		},

--- a/auth/oidc_discovery_test.go
+++ b/auth/oidc_discovery_test.go
@@ -1,0 +1,71 @@
+package auth
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestOIDCDiscoveryDoc_Parse(t *testing.T) {
+	body := []byte(`{
+		"issuer": "https://accounts.google.com",
+		"authorization_endpoint": "https://accounts.google.com/o/oauth2/v2/auth",
+		"token_endpoint": "https://oauth2.googleapis.com/token",
+		"userinfo_endpoint": "https://openidconnect.googleapis.com/v1/userinfo",
+		"jwks_uri": "https://www.googleapis.com/oauth2/v3/certs",
+		"subject_types_supported": ["public"],
+		"response_types_supported": ["code", "token", "id_token"]
+	}`)
+
+	var doc OIDCDiscoveryDoc
+	if err := json.Unmarshal(body, &doc); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if doc.Issuer != "https://accounts.google.com" {
+		t.Errorf("issuer = %q", doc.Issuer)
+	}
+	if doc.UserinfoEndpoint != "https://openidconnect.googleapis.com/v1/userinfo" {
+		t.Errorf("userinfo_endpoint = %q", doc.UserinfoEndpoint)
+	}
+}
+
+func TestOIDCDiscoveryDoc_IsValid(t *testing.T) {
+	tests := []struct {
+		name string
+		doc  OIDCDiscoveryDoc
+		want bool
+	}{
+		{
+			name: "complete",
+			doc: OIDCDiscoveryDoc{
+				Issuer: "https://example.com", AuthorizationEndpoint: "a",
+				TokenEndpoint: "t", JWKSURI: "j",
+				SubjectTypesSupported:  []string{"public"},
+				ResponseTypesSupported: []string{"code"},
+			},
+			want: true,
+		},
+		{
+			name: "missing issuer",
+			doc: OIDCDiscoveryDoc{
+				AuthorizationEndpoint: "a", TokenEndpoint: "t", JWKSURI: "j",
+				SubjectTypesSupported: []string{"public"}, ResponseTypesSupported: []string{"code"},
+			},
+			want: false,
+		},
+		{
+			name: "missing subject_types",
+			doc: OIDCDiscoveryDoc{
+				Issuer: "i", AuthorizationEndpoint: "a", TokenEndpoint: "t", JWKSURI: "j",
+				ResponseTypesSupported: []string{"code"},
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.doc.IsValid(); got != tt.want {
+				t.Errorf("IsValid() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/auth/provider_classifier.go
+++ b/auth/provider_classifier.go
@@ -1,6 +1,9 @@
 package auth
 
-import "context"
+import (
+	"context"
+	"fmt"
+)
 
 type ProviderClassification int
 
@@ -68,4 +71,44 @@ func ClassifyProvider(ctx context.Context, client *DiscoveryClient, providerID s
 		out.Classification = ClassificationOIDCCustomUserinfo
 	}
 	return out
+}
+
+// ValidateClassifiedProvider returns a slice of error messages describing
+// reasons the provider config is not safe to enable. An empty slice means
+// the provider is OK.
+func ValidateClassifiedProvider(p ClassifiedProvider, cfg OAuthProviderConfig) []string {
+	if p.Classification == ClassificationOIDCCompliant {
+		return nil
+	}
+
+	for _, ep := range cfg.UserInfo {
+		if v, ok := ep.Claims["subject_claim"]; ok && v != "" {
+			return nil
+		}
+	}
+
+	return []string{
+		fmt.Sprintf(
+			"OAuth provider %q is classified as %s; an explicit subject_claim mapping is required. "+
+				"Set OAUTH_PROVIDERS_%s_USERINFO_CLAIMS_SUBJECT_CLAIM (or claims.subject_claim in YAML) "+
+				"to the field name returned by the provider (e.g. \"id\" for GitHub, \"id\" for Microsoft Graph).",
+			p.ProviderID, p.Classification, providerIDToEnvKey(p.ProviderID),
+		),
+	}
+}
+
+func providerIDToEnvKey(id string) string {
+	out := make([]byte, len(id))
+	for i := 0; i < len(id); i++ {
+		c := id[i]
+		switch {
+		case c >= 'a' && c <= 'z':
+			out[i] = c - ('a' - 'A')
+		case c == '-':
+			out[i] = '_'
+		default:
+			out[i] = c
+		}
+	}
+	return string(out)
 }

--- a/auth/provider_classifier.go
+++ b/auth/provider_classifier.go
@@ -5,10 +5,10 @@ import "context"
 type ProviderClassification int
 
 const (
-	// ClassificationOIDCCompliant: discovery succeeds AND configured userinfo
-	// URL matches the discovery doc's userinfo_endpoint. Default `sub` mapping
-	// is safe.
-	ClassificationOIDCCompliant ProviderClassification = iota
+	// ClassificationNonOIDC is the zero value (fail-closed default): discovery
+	// failed or no issuer configured. No guarantee about userinfo response shape.
+	// Explicit subject_claim is required.
+	ClassificationNonOIDC ProviderClassification = iota
 
 	// ClassificationOIDCCustomUserinfo: discovery succeeds but the configured
 	// userinfo URL differs from the discovery doc's userinfo_endpoint. The
@@ -17,10 +17,10 @@ const (
 	// required.
 	ClassificationOIDCCustomUserinfo
 
-	// ClassificationNonOIDC: discovery failed or no issuer configured. No
-	// guarantee about userinfo response shape. Explicit subject_claim is
-	// required.
-	ClassificationNonOIDC
+	// ClassificationOIDCCompliant: discovery succeeds AND configured userinfo
+	// URL matches the discovery doc's userinfo_endpoint. Default `sub` mapping
+	// is safe.
+	ClassificationOIDCCompliant
 )
 
 func (c ProviderClassification) String() string {

--- a/auth/provider_classifier.go
+++ b/auth/provider_classifier.go
@@ -70,7 +70,7 @@ func ClassifyProvider(ctx context.Context, client *DiscoveryClient, providerID s
 		out.Classification = ClassificationOIDCCustomUserinfo
 		return out
 	}
-	if doc.UserinfoEndpoint != "" && cfg.UserInfo[0].URL == doc.UserinfoEndpoint {
+	if doc.UserinfoEndpoint != "" && canonicalizeURL(cfg.UserInfo[0].URL) == canonicalizeURL(doc.UserinfoEndpoint) {
 		out.Classification = ClassificationOIDCCompliant
 	} else {
 		out.Classification = ClassificationOIDCCustomUserinfo

--- a/auth/provider_classifier.go
+++ b/auth/provider_classifier.go
@@ -91,7 +91,8 @@ func ValidateClassifiedProvider(p ClassifiedProvider, cfg OAuthProviderConfig) [
 		fmt.Sprintf(
 			"OAuth provider %q is classified as %s; an explicit subject_claim mapping is required. "+
 				"Set OAUTH_PROVIDERS_%s_USERINFO_CLAIMS_SUBJECT_CLAIM (or claims.subject_claim in YAML) "+
-				"to the field name returned by the provider (e.g. \"id\" for GitHub, \"id\" for Microsoft Graph).",
+				"to the field name returned by the provider's primary userinfo endpoint (for example: \"id\" for GitHub or Microsoft Graph, \"sub\" for an OIDC-shaped endpoint). "+
+				"If the identity claim comes from a non-primary userinfo endpoint, use USERINFO_SECONDARY_CLAIMS_ or USERINFO_ADDITIONAL_CLAIMS_ instead.",
 			p.ProviderID, p.Classification, providerIDToEnvKey(p.ProviderID),
 		),
 	}

--- a/auth/provider_classifier.go
+++ b/auth/provider_classifier.go
@@ -1,0 +1,71 @@
+package auth
+
+import "context"
+
+type ProviderClassification int
+
+const (
+	// ClassificationOIDCCompliant: discovery succeeds AND configured userinfo
+	// URL matches the discovery doc's userinfo_endpoint. Default `sub` mapping
+	// is safe.
+	ClassificationOIDCCompliant ProviderClassification = iota
+
+	// ClassificationOIDCCustomUserinfo: discovery succeeds but the configured
+	// userinfo URL differs from the discovery doc's userinfo_endpoint. The
+	// operator is calling a non-OIDC userinfo endpoint (e.g. Microsoft Graph
+	// /me instead of Microsoft's OIDC userinfo). Explicit subject_claim is
+	// required.
+	ClassificationOIDCCustomUserinfo
+
+	// ClassificationNonOIDC: discovery failed or no issuer configured. No
+	// guarantee about userinfo response shape. Explicit subject_claim is
+	// required.
+	ClassificationNonOIDC
+)
+
+func (c ProviderClassification) String() string {
+	switch c {
+	case ClassificationOIDCCompliant:
+		return "OIDCCompliant"
+	case ClassificationOIDCCustomUserinfo:
+		return "OIDCCustomUserinfo"
+	case ClassificationNonOIDC:
+		return "NonOIDC"
+	}
+	return "Unknown"
+}
+
+type ClassifiedProvider struct {
+	ProviderID     string
+	Classification ProviderClassification
+	DiscoveryDoc   *OIDCDiscoveryDoc // nil for ClassificationNonOIDC
+}
+
+// ClassifyProvider buckets a provider based on discovery probe results and
+// configured userinfo URL. Compares the *primary* userinfo endpoint only
+// (cfg.UserInfo[0]); secondary/additional endpoints are operator extensions
+// and never affect classification.
+func ClassifyProvider(ctx context.Context, client *DiscoveryClient, providerID string, cfg OAuthProviderConfig) ClassifiedProvider {
+	out := ClassifiedProvider{ProviderID: providerID, Classification: ClassificationNonOIDC}
+
+	if cfg.Issuer == "" {
+		return out
+	}
+
+	doc, _ := client.Discover(ctx, cfg.Issuer)
+	if doc == nil {
+		return out
+	}
+	out.DiscoveryDoc = doc
+
+	if len(cfg.UserInfo) == 0 {
+		out.Classification = ClassificationOIDCCustomUserinfo
+		return out
+	}
+	if doc.UserinfoEndpoint != "" && cfg.UserInfo[0].URL == doc.UserinfoEndpoint {
+		out.Classification = ClassificationOIDCCompliant
+	} else {
+		out.Classification = ClassificationOIDCCustomUserinfo
+	}
+	return out
+}

--- a/auth/provider_classifier.go
+++ b/auth/provider_classifier.go
@@ -86,10 +86,21 @@ func ValidateClassifiedProvider(p ClassifiedProvider, cfg OAuthProviderConfig) [
 		return nil
 	}
 
-	// Provider has no external userinfo endpoints (e.g., the built-in TMI provider
-	// that handles user info internally); claim-mapping validation is N/A.
+	// The built-in TMI provider has no external userinfo endpoints — it issues
+	// its own tokens and resolves identity from internal state. All other
+	// providers MUST configure userinfo or they will 500 on first auth request.
 	if len(cfg.UserInfo) == 0 {
-		return nil
+		if p.ProviderID == "tmi" {
+			return nil
+		}
+		return []string{
+			fmt.Sprintf(
+				"OAuth provider %q has no userinfo endpoints configured but is not the built-in TMI provider; "+
+					"this would cause runtime authentication failures. Add a userinfo block with at least one endpoint, "+
+					"or remove this provider entirely.",
+				p.ProviderID,
+			),
+		}
 	}
 
 	for _, ep := range cfg.UserInfo {

--- a/auth/provider_classifier.go
+++ b/auth/provider_classifier.go
@@ -3,6 +3,8 @@ package auth
 import (
 	"context"
 	"fmt"
+
+	"github.com/ericfitz/tmi/internal/slogging"
 )
 
 type ProviderClassification int
@@ -55,7 +57,10 @@ func ClassifyProvider(ctx context.Context, client *DiscoveryClient, providerID s
 		return out
 	}
 
-	doc, _ := client.Discover(ctx, cfg.Issuer)
+	doc, err := client.Discover(ctx, cfg.Issuer)
+	if err != nil {
+		slogging.Get().Warn("OIDC discovery probe returned error for provider %q (issuer=%s): %v", providerID, cfg.Issuer, err)
+	}
 	if doc == nil {
 		return out
 	}
@@ -78,6 +83,12 @@ func ClassifyProvider(ctx context.Context, client *DiscoveryClient, providerID s
 // the provider is OK.
 func ValidateClassifiedProvider(p ClassifiedProvider, cfg OAuthProviderConfig) []string {
 	if p.Classification == ClassificationOIDCCompliant {
+		return nil
+	}
+
+	// Provider has no external userinfo endpoints (e.g., the built-in TMI provider
+	// that handles user info internally); claim-mapping validation is N/A.
+	if len(cfg.UserInfo) == 0 {
 		return nil
 	}
 
@@ -112,4 +123,22 @@ func providerIDToEnvKey(id string) string {
 		}
 	}
 	return string(out)
+}
+
+// ValidateAllOAuthProviders classifies and validates every enabled OAuth
+// provider. Returns a slice of human-readable error messages; an empty slice
+// means all enabled providers are safe to start. Disabled providers are
+// skipped.
+func ValidateAllOAuthProviders(ctx context.Context, client *DiscoveryClient, providers map[string]OAuthProviderConfig) []string {
+	var errs []string
+	for id, cfg := range providers {
+		if !cfg.Enabled {
+			continue
+		}
+		classified := ClassifyProvider(ctx, client, id, cfg)
+		if violations := ValidateClassifiedProvider(classified, cfg); len(violations) > 0 {
+			errs = append(errs, violations...)
+		}
+	}
+	return errs
 }

--- a/auth/provider_classifier_test.go
+++ b/auth/provider_classifier_test.go
@@ -60,6 +60,24 @@ func TestClassifyProvider_NonOIDC_NoIssuer(t *testing.T) {
 	}
 }
 
+func TestClassifyProvider_OIDCCompliant_TrailingSlash(t *testing.T) {
+	// The discovery doc returns a URL without a trailing slash, but the config
+	// was written with one. Raw equality would make this OIDCCustomUserinfo;
+	// canonicalization should make it OIDCCompliant.
+	srv := startDiscoveryServer(t, "https://issuer.example/userinfo")
+	defer srv.Close()
+
+	client := NewDiscoveryClient(2*time.Second, 1*time.Hour)
+	cfg := OAuthProviderConfig{
+		Issuer:   srv.URL,
+		UserInfo: []UserInfoEndpoint{{URL: "https://issuer.example/userinfo/"}},
+	}
+	got := ClassifyProvider(context.Background(), client, "testprovider", cfg)
+	if got.Classification != ClassificationOIDCCompliant {
+		t.Errorf("classification = %v, want OIDCCompliant (canonicalization should match trailing-slash URL)", got.Classification)
+	}
+}
+
 func TestClassifyProvider_NonOIDC_DiscoveryFails(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.NotFound(w, r)

--- a/auth/provider_classifier_test.go
+++ b/auth/provider_classifier_test.go
@@ -80,12 +80,14 @@ func TestClassifyProvider_NonOIDC_DiscoveryFails(t *testing.T) {
 func TestValidateClassifiedProvider(t *testing.T) {
 	tests := []struct {
 		name           string
+		providerID     string
 		classification ProviderClassification
 		userinfo       []UserInfoEndpoint
 		wantErrs       int
 	}{
 		{
 			name:           "no userinfo endpoints (built-in provider) skips validation",
+			providerID:     "tmi",
 			classification: ClassificationNonOIDC,
 			userinfo:       []UserInfoEndpoint{},
 			wantErrs:       0,
@@ -129,10 +131,20 @@ func TestValidateClassifiedProvider(t *testing.T) {
 			},
 			wantErrs: 0,
 		},
+		{
+			name:           "non-TMI provider with empty userinfo fails (would 500 at runtime)",
+			classification: ClassificationNonOIDC,
+			userinfo:       []UserInfoEndpoint{},
+			wantErrs:       1,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cp := ClassifiedProvider{ProviderID: "test", Classification: tt.classification}
+			id := tt.providerID
+			if id == "" {
+				id = "test"
+			}
+			cp := ClassifiedProvider{ProviderID: id, Classification: tt.classification}
 			cfg := OAuthProviderConfig{UserInfo: tt.userinfo}
 			errs := ValidateClassifiedProvider(cp, cfg)
 			if len(errs) != tt.wantErrs {

--- a/auth/provider_classifier_test.go
+++ b/auth/provider_classifier_test.go
@@ -76,3 +76,62 @@ func TestClassifyProvider_NonOIDC_DiscoveryFails(t *testing.T) {
 		t.Errorf("classification = %v, want NonOIDC", got.Classification)
 	}
 }
+
+func TestValidateClassifiedProvider(t *testing.T) {
+	tests := []struct {
+		name           string
+		classification ProviderClassification
+		userinfo       []UserInfoEndpoint
+		wantErrs       int
+	}{
+		{
+			name:           "OIDCCompliant accepts no explicit mappings",
+			classification: ClassificationOIDCCompliant,
+			userinfo:       []UserInfoEndpoint{{URL: "https://example/userinfo"}},
+			wantErrs:       0,
+		},
+		{
+			name:           "OIDCCustomUserinfo without subject_claim fails",
+			classification: ClassificationOIDCCustomUserinfo,
+			userinfo:       []UserInfoEndpoint{{URL: "https://graph.microsoft.com/v1.0/me"}},
+			wantErrs:       1,
+		},
+		{
+			name:           "OIDCCustomUserinfo with subject_claim passes",
+			classification: ClassificationOIDCCustomUserinfo,
+			userinfo:       []UserInfoEndpoint{{URL: "https://graph.microsoft.com/v1.0/me", Claims: map[string]string{"subject_claim": "id"}}},
+			wantErrs:       0,
+		},
+		{
+			name:           "NonOIDC without subject_claim fails",
+			classification: ClassificationNonOIDC,
+			userinfo:       []UserInfoEndpoint{{URL: "https://api.github.com/user"}},
+			wantErrs:       1,
+		},
+		{
+			name:           "NonOIDC with subject_claim on primary passes",
+			classification: ClassificationNonOIDC,
+			userinfo:       []UserInfoEndpoint{{URL: "https://api.github.com/user", Claims: map[string]string{"subject_claim": "id"}}},
+			wantErrs:       0,
+		},
+		{
+			name:           "NonOIDC with subject_claim on secondary endpoint passes",
+			classification: ClassificationNonOIDC,
+			userinfo: []UserInfoEndpoint{
+				{URL: "https://api.github.com/user/emails", Claims: map[string]string{"email_claim": "[0].email"}},
+				{URL: "https://api.github.com/user", Claims: map[string]string{"subject_claim": "id"}},
+			},
+			wantErrs: 0,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cp := ClassifiedProvider{ProviderID: "test", Classification: tt.classification}
+			cfg := OAuthProviderConfig{UserInfo: tt.userinfo}
+			errs := ValidateClassifiedProvider(cp, cfg)
+			if len(errs) != tt.wantErrs {
+				t.Errorf("got %d errs %v, want %d", len(errs), errs, tt.wantErrs)
+			}
+		})
+	}
+}

--- a/auth/provider_classifier_test.go
+++ b/auth/provider_classifier_test.go
@@ -1,0 +1,78 @@
+package auth
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func startDiscoveryServer(t *testing.T, userinfoEndpoint string) *httptest.Server {
+	t.Helper()
+	body := fmt.Sprintf(`{"issuer":"%%s","authorization_endpoint":"a","token_endpoint":"t","jwks_uri":"j","userinfo_endpoint":%q,"subject_types_supported":["public"],"response_types_supported":["code"]}`, userinfoEndpoint)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = fmt.Fprintf(w, body, "https://issuer.example")
+	}))
+	return srv
+}
+
+func TestClassifyProvider_OIDCCompliant(t *testing.T) {
+	srv := startDiscoveryServer(t, "https://issuer.example/userinfo")
+	defer srv.Close()
+
+	client := NewDiscoveryClient(2*time.Second, 1*time.Hour)
+	cfg := OAuthProviderConfig{
+		Issuer:   srv.URL,
+		UserInfo: []UserInfoEndpoint{{URL: "https://issuer.example/userinfo"}},
+	}
+	got := ClassifyProvider(context.Background(), client, "google", cfg)
+	if got.Classification != ClassificationOIDCCompliant {
+		t.Errorf("classification = %v, want OIDCCompliant", got.Classification)
+	}
+}
+
+func TestClassifyProvider_OIDCCustomUserinfo(t *testing.T) {
+	srv := startDiscoveryServer(t, "https://issuer.example/userinfo")
+	defer srv.Close()
+
+	client := NewDiscoveryClient(2*time.Second, 1*time.Hour)
+	cfg := OAuthProviderConfig{
+		Issuer:   srv.URL,
+		UserInfo: []UserInfoEndpoint{{URL: "https://graph.microsoft.com/v1.0/me"}},
+	}
+	got := ClassifyProvider(context.Background(), client, "microsoft", cfg)
+	if got.Classification != ClassificationOIDCCustomUserinfo {
+		t.Errorf("classification = %v, want OIDCCustomUserinfo", got.Classification)
+	}
+}
+
+func TestClassifyProvider_NonOIDC_NoIssuer(t *testing.T) {
+	client := NewDiscoveryClient(2*time.Second, 1*time.Hour)
+	cfg := OAuthProviderConfig{
+		Issuer:   "",
+		UserInfo: []UserInfoEndpoint{{URL: "https://api.github.com/user"}},
+	}
+	got := ClassifyProvider(context.Background(), client, "github", cfg)
+	if got.Classification != ClassificationNonOIDC {
+		t.Errorf("classification = %v, want NonOIDC", got.Classification)
+	}
+}
+
+func TestClassifyProvider_NonOIDC_DiscoveryFails(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	client := NewDiscoveryClient(2*time.Second, 1*time.Hour)
+	cfg := OAuthProviderConfig{
+		Issuer:   srv.URL,
+		UserInfo: []UserInfoEndpoint{{URL: "https://example.com/user"}},
+	}
+	got := ClassifyProvider(context.Background(), client, "weird", cfg)
+	if got.Classification != ClassificationNonOIDC {
+		t.Errorf("classification = %v, want NonOIDC", got.Classification)
+	}
+}

--- a/auth/provider_classifier_test.go
+++ b/auth/provider_classifier_test.go
@@ -85,6 +85,12 @@ func TestValidateClassifiedProvider(t *testing.T) {
 		wantErrs       int
 	}{
 		{
+			name:           "no userinfo endpoints (built-in provider) skips validation",
+			classification: ClassificationNonOIDC,
+			userinfo:       []UserInfoEndpoint{},
+			wantErrs:       0,
+		},
+		{
 			name:           "OIDCCompliant accepts no explicit mappings",
 			classification: ClassificationOIDCCompliant,
 			userinfo:       []UserInfoEndpoint{{URL: "https://example/userinfo"}},

--- a/auth/provider_validation_integration_test.go
+++ b/auth/provider_validation_integration_test.go
@@ -1,0 +1,44 @@
+// auth/provider_validation_integration_test.go
+package auth
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestValidateAllOAuthProviders_NonOIDCMissingSubjectClaim(t *testing.T) {
+	providers := map[string]OAuthProviderConfig{
+		"badgithub": {
+			ID:       "badgithub",
+			Enabled:  true,
+			Issuer:   "", // forces NonOIDC classification
+			UserInfo: []UserInfoEndpoint{{URL: "https://api.github.com/user"}},
+		},
+	}
+	client := NewDiscoveryClient(500*time.Millisecond, 1*time.Hour)
+	errs := ValidateAllOAuthProviders(context.Background(), client, providers)
+	if len(errs) == 0 {
+		t.Fatal("expected validation errors for non-OIDC provider missing subject_claim")
+	}
+	joined := strings.Join(errs, "\n")
+	if !strings.Contains(joined, "badgithub") || !strings.Contains(joined, "subject_claim") {
+		t.Errorf("error message did not include provider id and subject_claim guidance: %s", joined)
+	}
+}
+
+func TestValidateAllOAuthProviders_DisabledProvidersSkipped(t *testing.T) {
+	providers := map[string]OAuthProviderConfig{
+		"badgithub": {
+			ID:       "badgithub",
+			Enabled:  false, // disabled — should not be validated
+			UserInfo: []UserInfoEndpoint{{URL: "https://api.github.com/user"}},
+		},
+	}
+	client := NewDiscoveryClient(500*time.Millisecond, 1*time.Hour)
+	errs := ValidateAllOAuthProviders(context.Background(), client, providers)
+	if len(errs) != 0 {
+		t.Errorf("disabled provider should not produce validation errors, got %v", errs)
+	}
+}

--- a/auth/url_canonicalize.go
+++ b/auth/url_canonicalize.go
@@ -1,0 +1,42 @@
+package auth
+
+import (
+	"net/url"
+	"strings"
+)
+
+// canonicalizeURL normalizes a URL for equality comparison. Returns the input
+// unchanged on parse error (callers should compare conservatively when
+// canonicalization fails). Normalization steps:
+//   - Lowercase scheme and host
+//   - Strip default port (80 for http, 443 for https)
+//   - Strip trailing slash from path (only when path is more than just "/")
+//
+// This does NOT canonicalize across different hosts (e.g. host aliases).
+func canonicalizeURL(raw string) string {
+	u, err := url.Parse(raw)
+	if err != nil || u.Host == "" {
+		return raw
+	}
+
+	scheme := strings.ToLower(u.Scheme)
+	host := strings.ToLower(u.Host)
+
+	// Strip default port
+	if i := strings.LastIndex(host, ":"); i != -1 {
+		port := host[i+1:]
+		if (scheme == "http" && port == "80") || (scheme == "https" && port == "443") {
+			host = host[:i]
+		}
+	}
+
+	path := u.Path
+	if len(path) > 1 && strings.HasSuffix(path, "/") {
+		path = strings.TrimRight(path, "/")
+	}
+
+	u.Scheme = scheme
+	u.Host = host
+	u.Path = path
+	return u.String()
+}

--- a/auth/url_canonicalize_test.go
+++ b/auth/url_canonicalize_test.go
@@ -1,0 +1,73 @@
+package auth
+
+import (
+	"testing"
+)
+
+func TestCanonicalizeURL(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "trailing slash on multi-segment path is stripped",
+			input: "https://example.com/userinfo/",
+			want:  "https://example.com/userinfo",
+		},
+		{
+			name:  "trailing slash on root path is preserved",
+			input: "https://example.com/",
+			want:  "https://example.com/",
+		},
+		{
+			name:  "default https port is stripped",
+			input: "https://example.com:443/userinfo",
+			want:  "https://example.com/userinfo",
+		},
+		{
+			name:  "default http port is stripped",
+			input: "http://example.com:80/userinfo",
+			want:  "http://example.com/userinfo",
+		},
+		{
+			name:  "non-default port is preserved",
+			input: "https://example.com:8443/userinfo",
+			want:  "https://example.com:8443/userinfo",
+		},
+		{
+			name:  "uppercase scheme and host are lowercased",
+			input: "HTTPS://EXAMPLE.COM/userinfo",
+			want:  "https://example.com/userinfo",
+		},
+		{
+			name:  "already canonical URL is unchanged",
+			input: "https://openidconnect.googleapis.com/v1/userinfo",
+			want:  "https://openidconnect.googleapis.com/v1/userinfo",
+		},
+		{
+			name:  "empty string returns input unchanged",
+			input: "",
+			want:  "",
+		},
+		{
+			name:  "URL without host returns input unchanged",
+			input: "not-a-url",
+			want:  "not-a-url",
+		},
+		{
+			name:  "no path change when path is exactly root",
+			input: "https://example.com",
+			want:  "https://example.com",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := canonicalizeURL(tt.input)
+			if got != tt.want {
+				t.Errorf("canonicalizeURL(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}

--- a/auth/yaml_validation_fixture_test.go
+++ b/auth/yaml_validation_fixture_test.go
@@ -1,0 +1,252 @@
+package auth
+
+// yaml_validation_fixture_test.go tests that each dev/test YAML config file
+// passes ValidateAllOAuthProviders without errors. This is a regression guard
+// for the class of bug described in C1 (Issue #288): a stale or wrong userinfo
+// URL in a config file causing the validator to classify an OIDC-compliant
+// provider as OIDCCustomUserinfo, requiring an explicit subject_claim that
+// isn't present, and refusing to start.
+//
+// The test loads each YAML file directly (pure struct unmarshaling, no DB
+// or Redis connections) and runs the validator against a stubbed discovery
+// client whose HTTP transport returns canned discovery documents for the known
+// issuer URLs used in our dev/test configs.
+//
+// Files covered:
+//   - config-development.yml
+//   - config-development-mysql.yml
+//   - config-development-oci.yml
+//   - config-development-sqlite.yml
+//   - config-development-sqlserver.yml
+//   - config-test.yml
+//   - config-test-integration-pg.yml
+//   - config-test-integration-oci.yml
+//   - config-example.yml
+//
+// config-production.yml is intentionally excluded: it contains many disabled
+// providers with incomplete configs that are fine to disable but would fail if
+// we tried to validate them here.
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ericfitz/tmi/internal/config"
+	"gopkg.in/yaml.v3"
+)
+
+// cannedDiscoveryDocs maps issuer URL prefixes to their canned OIDC discovery documents.
+// Only the fields required by OIDCDiscoveryDoc.IsValid() plus userinfo_endpoint are set.
+// Issuers not in this map return 404 (treated as NonOIDC).
+var cannedDiscoveryDocs = map[string]OIDCDiscoveryDoc{
+	// Google's canonical OIDC issuer
+	"https://accounts.google.com": {
+		Issuer:                 "https://accounts.google.com",
+		AuthorizationEndpoint:  "https://accounts.google.com/o/oauth2/v2/auth",
+		TokenEndpoint:          "https://oauth2.googleapis.com/token",
+		UserinfoEndpoint:       "https://openidconnect.googleapis.com/v1/userinfo",
+		JWKSURI:                "https://www.googleapis.com/oauth2/v3/certs",
+		SubjectTypesSupported:  []string{"public"},
+		ResponseTypesSupported: []string{"code"},
+	},
+	// Microsoft consumer tenant
+	"https://login.microsoftonline.com/9188040d-6c67-4c5b-b112-36a304b66dad/v2.0": {
+		Issuer:                 "https://login.microsoftonline.com/9188040d-6c67-4c5b-b112-36a304b66dad/v2.0",
+		AuthorizationEndpoint:  "https://login.microsoftonline.com/9188040d-6c67-4c5b-b112-36a304b66dad/oauth2/v2.0/authorize",
+		TokenEndpoint:          "https://login.microsoftonline.com/9188040d-6c67-4c5b-b112-36a304b66dad/oauth2/v2.0/token",
+		UserinfoEndpoint:       "https://graph.microsoft.com/oidc/userinfo",
+		JWKSURI:                "https://login.microsoftonline.com/9188040d-6c67-4c5b-b112-36a304b66dad/discovery/v2.0/keys",
+		SubjectTypesSupported:  []string{"pairwise"},
+		ResponseTypesSupported: []string{"code"},
+	},
+	// Microsoft "consumers" tenant (used in config-test.yml)
+	"https://login.microsoftonline.com/consumers/v2.0": {
+		Issuer:                 "https://login.microsoftonline.com/consumers/v2.0",
+		AuthorizationEndpoint:  "https://login.microsoftonline.com/consumers/oauth2/v2.0/authorize",
+		TokenEndpoint:          "https://login.microsoftonline.com/consumers/oauth2/v2.0/token",
+		UserinfoEndpoint:       "https://graph.microsoft.com/oidc/userinfo",
+		JWKSURI:                "https://login.microsoftonline.com/consumers/discovery/v2.0/keys",
+		SubjectTypesSupported:  []string{"pairwise"},
+		ResponseTypesSupported: []string{"code"},
+	},
+}
+
+// cannedRoundTripper is an http.RoundTripper that serves canned OIDC discovery
+// documents for known issuers and returns 404 for everything else.
+type cannedRoundTripper struct{}
+
+func (cannedRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	// The DiscoveryClient requests <issuer>/.well-known/openid-configuration.
+	// Reconstruct the issuer from the request URL by stripping the well-known path.
+	reqURL := req.URL.String()
+	issuer := strings.TrimSuffix(reqURL, wellKnownPath)
+	issuer = strings.TrimSuffix(issuer, "/")
+
+	// Try exact match first, then prefix match for parameterized issuers
+	doc, ok := cannedDiscoveryDocs[issuer]
+	if !ok {
+		// Check by prefix — handles cases where the URL might have trailing slash variations
+		for k, v := range cannedDiscoveryDocs {
+			if strings.EqualFold(k, issuer) {
+				doc = v
+				ok = true
+				break
+			}
+		}
+	}
+
+	if !ok {
+		return &http.Response{
+			StatusCode: http.StatusNotFound,
+			Body:       http.NoBody,
+			Request:    req,
+		}, nil
+	}
+
+	body, err := json.Marshal(doc)
+	if err != nil {
+		return nil, err
+	}
+
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       newReadCloser(body),
+		Request:    req,
+	}, nil
+}
+
+// newReadCloser wraps a byte slice in an io.ReadCloser
+func newReadCloser(data []byte) *nopCloser {
+	return &nopCloser{r: strings.NewReader(string(data))}
+}
+
+type nopCloser struct {
+	r *strings.Reader
+}
+
+func (n *nopCloser) Read(p []byte) (int, error) { return n.r.Read(p) }
+func (n *nopCloser) Close() error               { return nil }
+
+// loadYAMLOAuthProviders loads OAuth provider configs from a YAML file without
+// initializing any infrastructure (DB, Redis). Returns only the OAuth provider
+// map extracted from the config YAML. Returns (nil, false) when the file does
+// not exist (callers should skip the test for missing gitignored files).
+func loadYAMLOAuthProviders(t *testing.T, yamlPath string) (map[string]OAuthProviderConfig, bool) {
+	t.Helper()
+
+	data, err := os.ReadFile(yamlPath) // #nosec G304 -- test fixture path only
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, false
+		}
+		t.Fatalf("loadYAMLOAuthProviders: read %s: %v", yamlPath, err)
+	}
+
+	// Use a minimal struct that only unmarshals the OAuth section we care about.
+	// Reuse internal/config types to stay aligned with production parsing.
+	var cfg config.Config
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		t.Fatalf("loadYAMLOAuthProviders: unmarshal %s: %v", yamlPath, err)
+	}
+
+	// Convert from internal/config types to auth types (same as ConfigFromUnified)
+	providers := make(map[string]OAuthProviderConfig)
+	for id, p := range cfg.Auth.OAuth.Providers {
+		var userInfo []UserInfoEndpoint
+		for _, ep := range p.UserInfo {
+			userInfo = append(userInfo, UserInfoEndpoint{
+				URL:    ep.URL,
+				Claims: ep.Claims,
+			})
+		}
+		providers[id] = OAuthProviderConfig{
+			ID:       p.ID,
+			Enabled:  p.Enabled,
+			Issuer:   p.Issuer,
+			UserInfo: userInfo,
+		}
+	}
+	return providers, true
+}
+
+// newCannedDiscoveryClient returns a DiscoveryClient whose HTTP requests are
+// served by cannedRoundTripper (no real network calls).
+func newCannedDiscoveryClient() *DiscoveryClient {
+	c := NewDiscoveryClient(2*time.Second, 1*time.Hour)
+	c.httpClient = &http.Client{
+		Transport: cannedRoundTripper{},
+		Timeout:   2 * time.Second,
+	}
+	return c
+}
+
+// projectRoot returns the repository root by walking up from the test's working
+// directory until we find a directory containing go.mod. Tests in auth/ have
+// their working directory set to auth/ by the Go test runner.
+func projectRoot(t *testing.T) string {
+	t.Helper()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("os.Getwd: %v", err)
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatal("could not find project root (go.mod not found)")
+		}
+		dir = parent
+	}
+}
+
+// TestYAMLConfigsPassOAuthValidation loads each dev/test YAML file and asserts
+// that ValidateAllOAuthProviders returns no errors when using canned discovery
+// responses for known issuers.
+func TestYAMLConfigsPassOAuthValidation(t *testing.T) {
+	root := projectRoot(t)
+
+	// Files to validate. config-production.yml is excluded (many intentionally
+	// incomplete disabled providers; validates as part of a different workflow).
+	files := []string{
+		"config-development.yml",
+		"config-development-mysql.yml",
+		"config-development-oci.yml",
+		"config-development-sqlite.yml",
+		"config-development-sqlserver.yml",
+		"config-test.yml",
+		"config-test-integration-pg.yml",
+		"config-test-integration-oci.yml",
+		"config-example.yml",
+	}
+
+	for _, f := range files {
+		t.Run(f, func(t *testing.T) {
+			absPath := filepath.Join(root, f)
+			providers, ok := loadYAMLOAuthProviders(t, absPath)
+			if !ok {
+				t.Logf("skipping %s (file not present — gitignored local config)", f)
+				return
+			}
+			if len(providers) == 0 {
+				t.Logf("no oauth providers found in %s (skipping)", f)
+				return
+			}
+
+			client := newCannedDiscoveryClient()
+			errs := ValidateAllOAuthProviders(context.Background(), client, providers)
+			if len(errs) > 0 {
+				t.Errorf("ValidateAllOAuthProviders(%s) returned %d error(s):\n%s",
+					f, len(errs), strings.Join(errs, "\n"))
+			}
+		})
+	}
+}

--- a/config-example.yml
+++ b/config-example.yml
@@ -119,7 +119,11 @@ auth:
         authorization_url: "https://accounts.google.com/o/oauth2/auth"
         token_url: "https://oauth2.googleapis.com/token"
         userinfo:
-          - url: "https://www.googleapis.com/oauth2/v3/userinfo"
+          # OIDC-canonical userinfo endpoint (matches Google's discovery doc).
+          # The legacy alias https://www.googleapis.com/oauth2/v3/userinfo also
+          # works at runtime but is misclassified as OIDCCustomUserinfo by the
+          # startup validator and would require an explicit subject_claim mapping.
+          - url: "https://openidconnect.googleapis.com/v1/userinfo"
             claims: {} # Will use defaults: sub, email, name
         issuer: "https://accounts.google.com"
         jwks_url: "https://www.googleapis.com/oauth2/v3/certs"


### PR DESCRIPTION
## Summary

Closes #288. Three-layer fix for the class of bug that caused Zack Gilburd's GitHub login to 500 in production:

1. **Operational** (already deployed to Heroku 2026-04-25): per-provider `OAUTH_PROVIDERS_*_USERINFO_CLAIMS_SUBJECT_CLAIM` env vars set; `scripts/configure-heroku-env.sh` updated to match.
2. **Startup validation** (this PR): probe each enabled OAuth provider's `<issuer>/.well-known/openid-configuration` at startup, classify it (`OIDCCompliant` / `OIDCCustomUserinfo` / `NonOIDC`), and refuse to start if the provider isn't OIDC-compliant on userinfo AND lacks an explicit `subject_claim` mapping. Operators get a precise error naming the env var to set.
3. **Runtime backstop** (this PR): if claim extraction ever yields empty `userInfo.ID` despite startup validation (hot-deployed config, transient upstream anomaly), respond **HTTP 502 Bad Gateway** (not 500) with a non-leaky message. Operator gets full diagnostics in the server log.

## Architecture

```
HTTP startup           Runtime auth flow
    │                       │
    ▼                       ▼
ConfigFromUnified       provider.GetUserInfo
    │                       │
    ▼                       ▼
ValidateAllOAuthProviders   userInfo.ID == ""?
    │                       │
    ▼                       ▼ (yes)
ClassifyProvider →      502 + "incomplete profile data"
    DiscoveryClient.Discover()    + diagnostic ERROR log
    │
    ▼
ValidateClassifiedProvider
    │
    ▼ (errors)
fail startup
```

Files:
- `auth/oidc_discovery.go` — `OIDCDiscoveryDoc`, `IsValid()`, `DiscoveryClient` (5s timeout, 24h cache, caches both successes and failures)
- `auth/provider_classifier.go` — classification + validation (zero value = `NonOIDC` for fail-closed default)
- `auth/url_canonicalize.go` — URL normalization (lowercase scheme/host, strip default ports, strip trailing slash) so trivial URL variations classify correctly
- `auth/handlers_token.go` + `handlers_token_helpers.go` — runtime backstop
- `auth/config_adapter.go` — wiring into both `InitAuthWithDB` and `InitAuthWithConfig`
- `auth/yaml_validation_fixture_test.go` — fixture test that loads each `config-*.yml` and runs through the validator with stubbed discovery, preventing regression of the YAML/validator drift class

## Plan deviations (all reviewer-driven)

- Reordered `ProviderClassification` iota so `NonOIDC` is the zero value (fail-closed default).
- Tightened the empty-userinfo bypass to TMI built-in provider only (any other provider with empty userinfo would 500 at runtime — startup validation now catches this).
- Added URL canonicalization (root-cause fix for the Google legacy-URL trap).
- Added fixture test loading real on-disk YAML configs (structural protection against the C1 class).
- Updated `config-development.yml` (gitignored) and `config-development-oci.yml` (gitignored) to use Google's canonical OIDC userinfo URL `https://openidconnect.googleapis.com/v1/userinfo`.
- Updated `config-example.yml` similarly so future dev configs derived from it pass validation by default.

## Test plan

- [x] `make lint` clean
- [x] `make build-server` succeeds
- [x] `make test-unit` passes (1626 tests, 0 failures)
- [x] Fixture test `TestYAMLConfigsPassOAuthValidation` loads each checked-in `config-*.yml` and runs through the validator
- [x] Reviewed by `superpowers:code-reviewer` per task + final whole-branch review + delta review of the C1/I1/C2 fixes
- [ ] Manual: `make start-dev` against a fresh checkout to confirm no regression in dev startup
- [ ] Manual: deliberately misconfigure a provider (drop `subject_claim` mapping for a non-OIDC provider) and confirm server refuses to start with a clear error message
- [ ] Manual: confirm Zack's GitHub login flow now succeeds in prod (already verified post-operational-fix; this PR adds the layered defenses)

## Follow-ups (not in this PR)

Filed as separate issues; non-blocking polish items reviewers flagged:

- Concurrent first-fetch dedup in `DiscoveryClient` (singleflight)
- Direct test for cache TTL expiry
- Hardcoded `subject_claim_path_default=sub` in runtime backstop log message
- Pre-existing 500 path in handlers_token.go leaks raw upstream error message into response body

🤖 Generated with [Claude Code](https://claude.com/claude-code)